### PR TITLE
Add logic to generate macaroon through LND

### DIFF
--- a/lnd/lnd.go
+++ b/lnd/lnd.go
@@ -93,3 +93,7 @@ func NewLNDclient(lndOptions LNDoptions) (result *LNDWrapper, err error) {
 func (wrapper *LNDWrapper) AddInvoice(ctx context.Context, req *lnrpc.Invoice, options ...grpc.CallOption) (*lnrpc.AddInvoiceResponse, error) {
 	return wrapper.client.AddInvoice(ctx, req, options...)
 }
+
+func (wrapper *LNDWrapper) BakeMacaroon(ctx context.Context, req *lnrpc.BakeMacaroonRequest, options ...grpc.CallOption) (*lnrpc.BakeMacaroonResponse, error) {
+	return wrapper.client.BakeMacaroon(ctx, req, options...)
+}

--- a/main.go
+++ b/main.go
@@ -33,7 +33,35 @@ func (svc *Service) getProtectedResource(c *gin.Context) {
 			return
 		}
 
-		macaroon := "AGIAJEemVQUTEyNCR0exk7ek90Cg=="
+		lnMacaroonReq := lnrpc.BakeMacaroonRequest{
+			Permissions: []*lnrpc.MacaroonPermission{
+				{
+					Entity: "invoices",
+					Action: "read",
+				},
+				{
+					Entity: "invoices",
+					Action: "write",
+				},
+				{
+					Entity: "address",
+					Action: "read",
+				},
+				{
+					Entity: "address",
+					Action: "write",
+				},
+			},
+			AllowExternalPermissions: false,
+		}
+
+		lndMacaroon, err := svc.lndClient.BakeMacaroon(ctx, &lnMacaroonReq)
+		if err != nil {
+			c.Error(err)
+			return
+		}
+
+		macaroon := lndMacaroon.Macaroon
 		invoice := lndInvoice.PaymentRequest
 
 		c.Writer.Header().Set("WWW-Authenticate", fmt.Sprintf("LSAT macaroon=%v, invoice=%v", macaroon, invoice))


### PR DESCRIPTION
Added logic to generate macaroon through LND and addition of macaroon under "WWW-Authenticate" field of response header.